### PR TITLE
Fix README curl URLs and update OWASP agentic naming

### DIFF
--- a/.claude/skills/owasp-security/SKILL.md
+++ b/.claude/skills/owasp-security/SKILL.md
@@ -144,13 +144,13 @@ When building or reviewing AI agent systems, check for:
 |------|-------------|------------|
 | ASI01: Goal Hijack | Prompt injection alters agent objectives | Input sanitization, goal boundaries, behavioral monitoring |
 | ASI02: Tool Misuse | Tools used in unintended ways | Least privilege, fine-grained permissions, validate I/O |
-| ASI03: Privilege Abuse | Credential escalation across agents | Short-lived scoped tokens, identity verification |
+| ASI03: Identity & Privilege Abuse | Delegated trust, inherited credentials, role chain exploits | Short-lived scoped tokens, identity verification |
 | ASI04: Supply Chain | Compromised plugins/MCP servers | Verify signatures, sandbox, allowlist plugins |
 | ASI05: Code Execution | Unsafe code generation/execution | Sandbox execution, static analysis, human approval |
 | ASI06: Memory Poisoning | Corrupted RAG/context data | Validate stored content, segment by trust level |
-| ASI07: Agent Comms | Spoofing between agents | Authenticate, encrypt, verify message integrity |
+| ASI07: Insecure Inter-Agent Comms | Spoofing/intercepting agent-to-agent messages | Authenticate, encrypt, verify message integrity |
 | ASI08: Cascading Failures | Errors propagate across systems | Circuit breakers, graceful degradation, isolation |
-| ASI09: Trust Exploitation | Social engineering via AI | Label AI content, user education, verification steps |
+| ASI09: Human-Agent Trust Exploitation | Over-trust in agents leveraged to manipulate users | Label AI content, user education, verification steps |
 | ASI10: Rogue Agents | Compromised agents acting maliciously | Behavior monitoring, kill switches, anomaly detection |
 
 ### Agent Security Checklist

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A Claude Code skill providing the latest OWASP security best practices (2025-202
 Add this skill to any project with a single command:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/agam/claude-code-owasp/main/.claude/skills/owasp-security/SKILL.md -o .claude/skills/owasp-security/SKILL.md --create-dirs
+curl -sL https://raw.githubusercontent.com/agamm/claude-code-owasp/main/.claude/skills/owasp-security/SKILL.md -o .claude/skills/owasp-security/SKILL.md --create-dirs
 ```
 
 Or install globally for all projects:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/agam/claude-code-owasp/main/.claude/skills/owasp-security/SKILL.md -o ~/.claude/skills/owasp-security/SKILL.md --create-dirs
+curl -sL https://raw.githubusercontent.com/agamm/claude-code-owasp/main/.claude/skills/owasp-security/SKILL.md -o ~/.claude/skills/owasp-security/SKILL.md --create-dirs
 ```
 
 ## What's Included


### PR DESCRIPTION
## Summary
- Fix GitHub username in README curl URLs (`agam` → `agamm`) so install commands no longer 404
- Update Agentic AI risk names (ASI03, ASI07, ASI09) to match official OWASP Top 10 for Agentic Applications 2026

Fixes #1

## Test plan
- [ ] Verify `curl -sL https://raw.githubusercontent.com/agamm/claude-code-owasp/main/.claude/skills/owasp-security/SKILL.md` returns 200
- [ ] Confirm agentic risk names match https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/

🤖 Generated with [Claude Code](https://claude.com/claude-code)